### PR TITLE
fix: Correct commenting to issues

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -87,7 +87,7 @@ runs:
           input.txt
 
     - name: Comment
-      if: ${{ inputs.github_comments == true }}
+      if: ${{ inputs.github_comments == 'true' }}
       shell: bash
       run: |
         # --edit-last will fail if there is no previous comment by the bot. See https://github.com/cli/cli/issues/10370


### PR DESCRIPTION
As a regression of https://github.com/espressif/docs-bot-action/pull/2, currently the commenting stage is never run. It seems to be related to https://github.com/actions/runner/issues/1483.

According to many guides the following should also work:
```yml
if: ${{ inputs.github_comments }}
```
(no it doesn't)

I've tried to set `type: boolean` for the input but neither that helped.

I've tested this solution indirectly in my fork. I hope this time I've got it right.