### PR TITLE
Reduce the query length if it is long by using simple heuristics

### DIFF
--- a/bot_action/bot_action.py
+++ b/bot_action/bot_action.py
@@ -7,7 +7,15 @@
 import argparse
 import json
 import os
+import re
 import requests
+
+"""
+There is a hard bot query limit of 15000 characters. Above this the query will be rejected by the server. It is not
+possible to increase it or work around the limit. The following limit is smaller in order to account for the JSON
+request overhead.
+"""
+QUERY_LIMIT = 14000
 
 
 def get_suggestion(issue_body: str) -> str:
@@ -28,14 +36,59 @@ def get_suggestion(issue_body: str) -> str:
     return answer
 
 
+def shorten_backtick_blocks(text: str) -> str:
+    """
+    Iterate through the text and find all the triple backtick blocks ```.
+    For each block, keep the first and the last couple of characters and add [redacted] in between.
+    """
+
+    CHAR_BLOCK = 200  # number of characters to keep at the beginning and at the end of the block
+    backtick_block_re = re.compile(r'```.+?```', re.DOTALL)  # non-greedy search will not go over the block boundary
+
+    """
+    The text cannot be modified on the fly because indexes to the original search will change. Indexes will be stored in
+    idx, a simple list, for example:
+    [startA, endA, startB, endB] - where blocks between startA and endA, and startB and endB should be removed.
+    If we add 0 to the beginning and "length" to the end of the list, and iterate through the list then we will get
+    blocks which will need to be kept.
+    [0, startA, endA, startB, endB, length] - which means that the following blocks should be kept:
+                                                    - between 0 and startA,
+                                                    - between endA and startB,
+                                                    - between endB and length.
+    """
+    idx = [0]
+    for m in re.finditer(backtick_block_re, text):
+        start = m.start()
+        end = m.end()
+        length = end - start
+
+        if length > 2 * CHAR_BLOCK:  # 2 is for accounting for the offset at the beginning and the end
+            idx += [start + CHAR_BLOCK, end - CHAR_BLOCK]
+
+    idx += [len(text)]
+
+    blocks_to_keep = []
+    idx_iter = iter(idx)
+    for start, end in zip(idx_iter, idx_iter):  # (A, B), (C, D), (E, F) from [A, B, C, D, E, F]
+        blocks_to_keep += [text[start:end]]
+
+    return '\n[redacted]\n'.join(blocks_to_keep)
+
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('input_file', type=str, default=None)
     args = parser.parse_args()
 
+    text_reducing_heuristics = (shorten_backtick_blocks,)
+
     if args.input_file:
         with open(args.input_file, 'r', encoding='utf-8') as f:
-            print(get_suggestion(f.read()))
+            input_text = f.read()
+            if len(input_text) > QUERY_LIMIT:
+                for heuristic in text_reducing_heuristics:
+                    input_text = heuristic(input_text)
+            print(get_suggestion(input_text))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- Long triple backtick blocks are shortened in order to reduce the size of the query. This help mostly with esptool issues where long trace output is added this way.
- Master fails at https://github.com/espressif/docs-bot-action/actions/runs/14857036746 and this branch passes at https://github.com/espressif/docs-bot-action/actions/runs/14857033560 with the same input.